### PR TITLE
Add US Vim and Emacs Unicode entry layouts

### DIFF
--- a/us_emacs.yaml
+++ b/us_emacs.yaml
@@ -1,0 +1,264 @@
+# Mapping for US keyboards with Emacs insert-char unicode entry.
+name: US Emacs
+identifier: us_emacs
+unicode:  |
+  func begin() {
+  }
+
+  func emit(unicode) {
+    flushAndSleep();
+
+    //emitKeyCode(0x41b); // Alt + X
+    //flushAndSleep();
+    //releaseModifiers();
+    //flushAndSleep();
+    //emitKeyCode(0x0c); // i
+    //emitKeyCode(0x11); // n
+    //emitKeyCode(0x16); // s
+    //emitKeyCode(0x08); // e
+    //emitKeyCode(0x15); // r
+    //emitKeyCode(0x17); // t
+    //emitKeyCode(0x2d); // -
+    //emitKeyCode(0x06); // c
+    //emitKeyCode(0x0b); // h
+    //emitKeyCode(0x04); // a
+    //emitKeyCode(0x15); // r
+    //emitKeyCode(0x28); // Enter
+    //flushAndSleep();
+
+    emitKeyCode(0x11b); // Control + X
+    flushAndSleep();
+    releaseModifiers();
+    flushAndSleep();
+    emitKeyCode(0x25); // 8
+    emitKeyCode(0x28); // Enter
+    flushAndSleep();
+
+    emitHex(unicode);
+    emitKeyCode(0x28); // Enter
+    flushAndSleep();
+  }
+
+  func end() {
+  }
+
+  func flushAndSleep() {
+    flush();
+    sleep(30);
+  }
+
+  func emitHex(value) {
+    const HEX_SCAN_CODES = [[
+      27 // 0
+      1e 1f 20 21 22 23 24 25 26 // 1-9
+      04 05 06 07 08 09 // a-f
+    ]];
+    var quotient = value >> 4;
+    if (quotient) {
+      emitHex(quotient);
+    }
+    emitKeyCode(HEX_SCAN_CODES[value & 0xf]);
+  }
+keyCodes:
+  # Number row
+  "`": 0x35
+  "~":
+    modifiers: shift
+    scanCode: 0x35
+  "1": 0x1e
+  "!":
+    modifiers: shift
+    scanCode: 0x1e
+  "2": 0x1f
+  "@":
+    modifiers: shift
+    scanCode: 0x1f
+  "3": 0x20
+  "#":
+    modifiers: shift
+    scanCode: 0x20
+  "4": 0x21
+  "$":
+    modifiers: shift
+    scanCode: 0x21
+  "5": 0x22
+  "%":
+    modifiers: shift
+    scanCode: 0x22
+  "6": 0x23
+  "^":
+    modifiers: shift
+    scanCode: 0x23
+  "7": 0x24
+  "&":
+    modifiers: shift
+    scanCode: 0x24
+  "8": 0x25
+  "*":
+    modifiers: shift
+    scanCode: 0x25
+  "9": 0x26
+  "(":
+    modifiers: shift
+    scanCode: 0x26
+  "0": 0x27
+  ")":
+    modifiers: shift
+    scanCode: 0x27
+  "-": 0x2d
+  "_":
+    modifiers: shift
+    scanCode: 0x2d
+  "=": 0x2e
+  "+":
+    modifiers: shift
+    scanCode: 0x2e
+  "\b": 0x2a
+
+  # Top letter row
+  "\t": 0x2b
+  "q": 0x14
+  "Q":
+    modifiers: shift
+    scanCode: 0x14
+  "w": 0x1a
+  "W":
+    modifiers: shift
+    scanCode: 0x1a
+  "e": 0x08
+  "E":
+    modifiers: shift
+    scanCode: 0x8
+  "r": 0x15
+  "R":
+    modifiers: shift
+    scanCode: 0x15
+  "t": 0x17
+  "T":
+    modifiers: shift
+    scanCode: 0x17
+  "y": 0x1c
+  "Y":
+    modifiers: shift
+    scanCode: 0x1c
+  "u": 0x18
+  "U":
+    modifiers: shift
+    scanCode: 0x18
+  "i": 0x0c
+  "I":
+    modifiers: shift
+    scanCode: 0x0c
+  "o": 0x12
+  "O":
+    modifiers: shift
+    scanCode: 0x12
+  "p": 0x13
+  "P":
+    modifiers: shift
+    scanCode: 0x13
+  "[": 0x2f
+  "{":
+    modifiers: shift
+    scanCode: 0x2f
+  "]": 0x30
+  "}":
+    modifiers: shift
+    scanCode: 0x30
+  "\\": 0x31
+  "|":
+    modifiers: shift
+    scanCode: 0x31
+
+  # Middle letter row
+  "a": 0x04
+  "A":
+    modifiers: shift
+    scanCode: 0x04
+  "s": 0x16
+  "S":
+    modifiers: shift
+    scanCode: 0x16
+  "d": 0x07
+  "D":
+    modifiers: shift
+    scanCode: 0x07
+  "f": 0x09
+  "F":
+    modifiers: shift
+    scanCode: 0x09
+  "g": 0x0a
+  "G":
+    modifiers: shift
+    scanCode: 0x0a
+  "h": 0x0b
+  "H":
+    modifiers: shift
+    scanCode: 0x0b
+  "j": 0x0d
+  "J":
+    modifiers: shift
+    scanCode: 0x0d
+  "k": 0x0e
+  "K":
+    modifiers: shift
+    scanCode: 0x0e
+  "l": 0x0f
+  "L":
+    modifiers: shift
+    scanCode: 0x0f
+  ";": 0x33
+  ":":
+    modifiers: shift
+    scanCode: 0x33
+  "'": 0x34
+  "\"":
+    modifiers: shift
+    scanCode: 0x34
+  "\r": 0x28
+  "\n": 0x28
+
+  # Lower letter row
+  "z": 0x1d
+  "Z":
+    modifiers: shift
+    scanCode: 0x1d
+  "x": 0x1b
+  "X":
+    modifiers: shift
+    scanCode: 0x1b
+  "c": 0x06
+  "C":
+    modifiers: shift
+    scanCode: 0x06
+  "v": 0x19
+  "V":
+    modifiers: shift
+    scanCode: 0x19
+  "b": 0x05
+  "B":
+    modifiers: shift
+    scanCode: 0x05
+  "n": 0x11
+  "N":
+    modifiers: shift
+    scanCode: 0x11
+  "m": 0x10
+  "M":
+    modifiers: shift
+    scanCode: 0x10
+  ",": 0x36
+  "<":
+    modifiers: shift
+    scanCode: 0x36
+  ".": 0x37
+  ">":
+    modifiers: shift
+    scanCode: 0x37
+  "/": 0x38
+  "?":
+    modifiers: shift
+    scanCode: 0x38
+
+  # Space bar
+  " ": 0x2c

--- a/us_vim.yaml
+++ b/us_vim.yaml
@@ -1,0 +1,245 @@
+# Mapping for US keyboards with Vim insert mode unicode entry.
+name: US Vim
+identifier: us_vim
+unicode:  |
+  func begin() {
+  }
+
+  func emit(unicode) {
+    flushAndSleep();
+    emitKeyCode(0x119); // Control + V
+    flushAndSleep();
+    releaseModifiers();
+    flushAndSleep();
+    emitKeyCode(0x218); // Shift + U
+    releaseModifiers();
+    emitHex(unicode);
+    flushAndSleep();
+  }
+
+  func end() {
+  }
+
+  func flushAndSleep() {
+    flush();
+    sleep(30);
+  }
+
+  func emitHex(value) {
+    const HEX_SCAN_CODES = [[
+      27 // 0
+      1e 1f 20 21 22 23 24 25 26 // 1-9
+      04 05 06 07 08 09 // a-f
+    ]];
+    emitKeyCode(HEX_SCAN_CODES[(value >> 28) & 0xf]);
+    emitKeyCode(HEX_SCAN_CODES[(value >> 24) & 0xf]);
+    emitKeyCode(HEX_SCAN_CODES[(value >> 20) & 0xf]);
+    emitKeyCode(HEX_SCAN_CODES[(value >> 16) & 0xf]);
+    emitKeyCode(HEX_SCAN_CODES[(value >> 12) & 0xf]);
+    emitKeyCode(HEX_SCAN_CODES[(value >>  8) & 0xf]);
+    emitKeyCode(HEX_SCAN_CODES[(value >>  4) & 0xf]);
+    emitKeyCode(HEX_SCAN_CODES[ value        & 0xf]);
+  }
+keyCodes:
+  # Number row
+  "`": 0x35
+  "~":
+    modifiers: shift
+    scanCode: 0x35
+  "1": 0x1e
+  "!":
+    modifiers: shift
+    scanCode: 0x1e
+  "2": 0x1f
+  "@":
+    modifiers: shift
+    scanCode: 0x1f
+  "3": 0x20
+  "#":
+    modifiers: shift
+    scanCode: 0x20
+  "4": 0x21
+  "$":
+    modifiers: shift
+    scanCode: 0x21
+  "5": 0x22
+  "%":
+    modifiers: shift
+    scanCode: 0x22
+  "6": 0x23
+  "^":
+    modifiers: shift
+    scanCode: 0x23
+  "7": 0x24
+  "&":
+    modifiers: shift
+    scanCode: 0x24
+  "8": 0x25
+  "*":
+    modifiers: shift
+    scanCode: 0x25
+  "9": 0x26
+  "(":
+    modifiers: shift
+    scanCode: 0x26
+  "0": 0x27
+  ")":
+    modifiers: shift
+    scanCode: 0x27
+  "-": 0x2d
+  "_":
+    modifiers: shift
+    scanCode: 0x2d
+  "=": 0x2e
+  "+":
+    modifiers: shift
+    scanCode: 0x2e
+  "\b": 0x2a
+
+  # Top letter row
+  "\t": 0x2b
+  "q": 0x14
+  "Q":
+    modifiers: shift
+    scanCode: 0x14
+  "w": 0x1a
+  "W":
+    modifiers: shift
+    scanCode: 0x1a
+  "e": 0x08
+  "E":
+    modifiers: shift
+    scanCode: 0x8
+  "r": 0x15
+  "R":
+    modifiers: shift
+    scanCode: 0x15
+  "t": 0x17
+  "T":
+    modifiers: shift
+    scanCode: 0x17
+  "y": 0x1c
+  "Y":
+    modifiers: shift
+    scanCode: 0x1c
+  "u": 0x18
+  "U":
+    modifiers: shift
+    scanCode: 0x18
+  "i": 0x0c
+  "I":
+    modifiers: shift
+    scanCode: 0x0c
+  "o": 0x12
+  "O":
+    modifiers: shift
+    scanCode: 0x12
+  "p": 0x13
+  "P":
+    modifiers: shift
+    scanCode: 0x13
+  "[": 0x2f
+  "{":
+    modifiers: shift
+    scanCode: 0x2f
+  "]": 0x30
+  "}":
+    modifiers: shift
+    scanCode: 0x30
+  "\\": 0x31
+  "|":
+    modifiers: shift
+    scanCode: 0x31
+
+  # Middle letter row
+  "a": 0x04
+  "A":
+    modifiers: shift
+    scanCode: 0x04
+  "s": 0x16
+  "S":
+    modifiers: shift
+    scanCode: 0x16
+  "d": 0x07
+  "D":
+    modifiers: shift
+    scanCode: 0x07
+  "f": 0x09
+  "F":
+    modifiers: shift
+    scanCode: 0x09
+  "g": 0x0a
+  "G":
+    modifiers: shift
+    scanCode: 0x0a
+  "h": 0x0b
+  "H":
+    modifiers: shift
+    scanCode: 0x0b
+  "j": 0x0d
+  "J":
+    modifiers: shift
+    scanCode: 0x0d
+  "k": 0x0e
+  "K":
+    modifiers: shift
+    scanCode: 0x0e
+  "l": 0x0f
+  "L":
+    modifiers: shift
+    scanCode: 0x0f
+  ";": 0x33
+  ":":
+    modifiers: shift
+    scanCode: 0x33
+  "'": 0x34
+  "\"":
+    modifiers: shift
+    scanCode: 0x34
+  "\r": 0x28
+  "\n": 0x28
+
+  # Lower letter row
+  "z": 0x1d
+  "Z":
+    modifiers: shift
+    scanCode: 0x1d
+  "x": 0x1b
+  "X":
+    modifiers: shift
+    scanCode: 0x1b
+  "c": 0x06
+  "C":
+    modifiers: shift
+    scanCode: 0x06
+  "v": 0x19
+  "V":
+    modifiers: shift
+    scanCode: 0x19
+  "b": 0x05
+  "B":
+    modifiers: shift
+    scanCode: 0x05
+  "n": 0x11
+  "N":
+    modifiers: shift
+    scanCode: 0x11
+  "m": 0x10
+  "M":
+    modifiers: shift
+    scanCode: 0x10
+  ",": 0x36
+  "<":
+    modifiers: shift
+    scanCode: 0x36
+  ".": 0x37
+  ">":
+    modifiers: shift
+    scanCode: 0x37
+  "/": 0x38
+  "?":
+    modifiers: shift
+    scanCode: 0x38
+
+  # Space bar
+  " ": 0x2c


### PR DESCRIPTION
These layouts allow for entering Unicode characters directly in Vim (using `^VU01234567` style insert mode literals) and Emacs (using `C-x 8 RET` / `M-x insert-char`).